### PR TITLE
remove encoding from toUrn

### DIFF
--- a/src/utils/Udi.ts
+++ b/src/utils/Udi.ts
@@ -108,12 +108,12 @@ class Udi {
     return base64 + "=".repeat(paddingNeeded);
   }
 
-  toUrn(encoding: "hex" | "base32" | "base64" = "hex"): string {
-    const storeIdStr = this.bufferToString(this._storeId, encoding);
+  toUrn(): string {
+    const storeIdStr = this.bufferToString(this._storeId, "hex");
     let urn = `${Udi.namespace}:${this.chainName}:${storeIdStr}`;
 
     if (this._rootHash) {
-      const rootHashStr = this.bufferToString(this._rootHash, encoding);
+      const rootHashStr = this.bufferToString(this._rootHash, "hex");
       urn += `:${rootHashStr}`;
     }
 

--- a/src/utils/Udi.ts
+++ b/src/utils/Udi.ts
@@ -83,14 +83,14 @@ class Udi {
     return input + "=".repeat(paddingNeeded);
   }
 
-  toUrn(encoding: "hex" | "base32" = "hex"): string {
-    const storeIdStr = this.formatBufferAsEncoding(this._storeIdHex, encoding);
+  toUrn(): string {
+    const storeIdStr = this.formatBufferAsEncoding(this._storeIdHex, "hex");
     let urn = `${Udi.namespace}:${this.chainName}:${storeIdStr}`;
 
     if (this._rootHashHex) {
       const rootHashStr = this.formatBufferAsEncoding(
         this._rootHashHex,
-        encoding
+        "hex"
       );
       urn += `:${rootHashStr}`;
     }


### PR DESCRIPTION
Remove encoding option to ensure that the urn is canonical for a given store, roothash, and resource key combination